### PR TITLE
Add panel position preference

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -242,6 +242,7 @@ const Azan = GObject.registerClass(
             this._updateAutoLocation();
             this._opt_latitude = this._settings.get_double('latitude');
             this._opt_longitude = this._settings.get_double('longitude');
+            this._opt_panel_position = this._settings.get_int('panel-position');
             this._opt_timeformat12 = this._settings.get_boolean('time-format-12');
             this._opt_timezone = this._settings.get_int('timezone');
             this._opt_concise_list = this._settings.get_int('concise-list');
@@ -284,6 +285,10 @@ const Azan = GObject.registerClass(
             this._settings.connect('changed::' + 'longitude', (settings, key) => {
                 this._opt_longitude = settings.get_double(key);
 
+                this._updateLabel();
+            });
+            this._settings.connect('changed::' + 'panel-position', (settings, key) => {
+                this._opt_panel_position = settings.get_int(key);
                 this._updateLabel();
             });
             this._settings.connect('changed::' + 'time-format-12', (settings, key) => {
@@ -453,6 +458,7 @@ const Azan = GObject.registerClass(
             this._updateIslamicDate();
             this._handlePrayerNotifications(isAfterAzan, minDiffMinutes, nearestPrayerId, timesStr);
             this._updateIndicatorText(isTimeForPraying, isAfterAzan, minDiffMinutes, nearestPrayerId);
+            this._updateLabelPosition();
         }
 
         _updateIslamicDate() {
@@ -482,6 +488,22 @@ const Azan = GObject.registerClass(
             } else {
                 this.indicatorText.set_text(this._timeNames[nearestPrayerId] + ' -' + this._formatRemainingTimeFromMinutes(minDiffMinutes));
             }
+        }
+
+        _updateLabelPosition() {
+            delete Main.panel.statusArea['azan'];
+            let position;
+            switch (this._opt_panel_position) {
+                case 1:
+                    position = 'left';
+                    break;
+                case 2:
+                    position = 'right';
+                    break;
+                default:
+                    position = 'center';
+            }
+            Main.panel.addToStatusArea('azan', this, 1, position);
         }
 
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -458,7 +458,7 @@ const Azan = GObject.registerClass(
             this._updateIslamicDate();
             this._handlePrayerNotifications(isAfterAzan, minDiffMinutes, nearestPrayerId, timesStr);
             this._updateIndicatorText(isTimeForPraying, isAfterAzan, minDiffMinutes, nearestPrayerId);
-            this._updateLabelPosition();
+            this._updatePanelPosition();
         }
 
         _updateIslamicDate() {
@@ -490,7 +490,7 @@ const Azan = GObject.registerClass(
             }
         }
 
-        _updateLabelPosition() {
+        _updatePanelPosition() {
             delete Main.panel.statusArea['azan'];
             let position;
             switch (this._opt_panel_position) {

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -126,6 +126,10 @@ class Settings {
             title: _("Timezone"),
             model: this.#timezoneOptions()
         });
+        this.field_panel_position = new Adw.ComboRow({
+            title: _("Panel position"),
+            model: this.#labelPositionOptions()
+        })
         this.field_which_times_mode = new Adw.ComboRow({
             title: _("Which times?"),
             model: this.#whichTimesOptions()
@@ -153,6 +157,7 @@ class Settings {
         this.locationGroup.add(this.field_longitude);
 
         this.displayGroup = new Adw.PreferencesGroup({ title: _('Display') });
+        this.displayGroup.add(this.field_panel_position);
         this.displayGroup.add(this.field_time_format_12_toggle);
         this.displayGroup.add(this.field_which_times_mode);
         
@@ -175,6 +180,11 @@ class Settings {
         this.schema.bind('auto-location',
             this.field_auto_location_toggle,
             'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+        this.schema.bind('panel-position',
+            this.field_panel_position,
+            'selected',
             Gio.SettingsBindFlags.DEFAULT
         );
         this.schema.bind('time-format-12',
@@ -325,6 +335,19 @@ class Settings {
             _("GMT +12:00"),
             _("GMT +13:00"),
             _("GMT +14:00")
+        ];
+        let list = new Gtk.StringList();
+        for (let option of options) {
+            list.append(option)
+        }
+        return list;
+    }
+
+    #labelPositionOptions() {
+        let options = [
+            _("Center"),
+            _("Left"),
+            _("Right")
         ];
         let list = new Gtk.StringList();
         for (let option of options) {

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -128,7 +128,7 @@ class Settings {
         });
         this.field_panel_position = new Adw.ComboRow({
             title: _("Panel position"),
-            model: this.#labelPositionOptions()
+            model: this.#panelPositionOptions()
         })
         this.field_which_times_mode = new Adw.ComboRow({
             title: _("Which times?"),
@@ -343,7 +343,7 @@ class Settings {
         return list;
     }
 
-    #labelPositionOptions() {
+    #panelPositionOptions() {
         let options = [
             _("Center"),
             _("Left"),

--- a/src/schemas/org.gnome.shell.extensions.azan.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.azan.gschema.xml
@@ -32,6 +32,12 @@
         <description>Longitude of your location</description>
     </key>
 
+    <key type="i" name="panel-position">
+        <default>0</default>
+        <summary>Panel position</summary>
+        <description>Position in the top panel</description>
+    </key>
+
     <key type="b" name="time-format-12">
         <default>false</default>
         <summary>AM/PM time format</summary>


### PR DESCRIPTION
Assalamu Alaikum.

This PR adds a preference entry to allow changing the extension position in the top bar, to the left, right, or center.

Wanted to make this as the original extension (by faisaloo) was attached to the right, and I already have enough extensions attached to the clock in the center.

Tested on GNOME 45.